### PR TITLE
Fix: Reference upstream repo in example config

### DIFF
--- a/proxmox-config/opencode/README.md
+++ b/proxmox-config/opencode/README.md
@@ -39,7 +39,7 @@ export LOG_LEVEL=INFO
 The MCP command in `opencode.jsonc` sources the environment file automatically:
 
 ```json
-"command": ["sh", "-c", ". ./proxmox-mcp.env && uvx --from git+https://github.com/NewsRx/ProxmoxMCP-Plus.git proxmox-mcp"]
+"command": ["sh", "-c", ". ./proxmox-mcp.env && uvx --from git+https://github.com/RekklesNA/ProxmoxMCP-Plus.git proxmox-mcp"]
 ```
 
 **No manual sourcing needed** - OpenCode runs the MCP, and the MCP command sources `proxmox-mcp.env` before starting.

--- a/proxmox-config/opencode/opencode.jsonc.example
+++ b/proxmox-config/opencode/opencode.jsonc.example
@@ -7,7 +7,7 @@
   "mcp": {
     "proxmox-mcp-plus": {
       "type": "local",
-      "command": ["sh", "-c", ". ./proxmox-mcp.env && uvx --from git+https://github.com/NewsRx/ProxmoxMCP-Plus.git proxmox-mcp"],
+      "command": ["sh", "-c", ". ./proxmox-mcp.env && uvx --from git+https://github.com/RekklesNA/ProxmoxMCP-Plus.git proxmox-mcp"],
       "enabled": true
     }
   }


### PR DESCRIPTION
## Summary

Update `opencode.jsonc.example` and `README.md` to reference the upstream repository (`RekklesNA/ProxmoxMCP-Plus.git`) instead of the fork (`NewsRx/ProxmoxMCP-Plus.git`).

## Changes

- `opencode.jsonc.example`: Changed `uvx --from` URL to upstream repo
- `README.md`: Updated example command to reference upstream repo

## Why

The example configuration should reference the upstream repository for users who install directly from the official source.

Related to https://github.com/RekklesNA/ProxmoxMCP-Plus/issues/41

*Co-authored with AI: OpenCode (ollama-cloud/glm-5)*